### PR TITLE
Add `#[derive(Clone)]` to `MockNow`

### DIFF
--- a/tokio-timer/tests/support/mod.rs
+++ b/tokio-timer/tests/support/mod.rs
@@ -37,7 +37,7 @@ pub struct MockTime {
     _p: PhantomData<Rc<()>>,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct MockNow {
     inner: Inner,
     _p: PhantomData<Rc<()>>,


### PR DESCRIPTION
This should fix the build on CI.